### PR TITLE
Create channel/discussion fix (dark theme css)

### DIFF
--- a/docs/RocketChat/CSS/RocketChat-DarkTheme.css
+++ b/docs/RocketChat/CSS/RocketChat-DarkTheme.css
@@ -228,6 +228,20 @@ option {
 	color: #dcddde;
 }
 
+.rc-input__title {
+    color: #dcddde;
+}
+
+.rc-switch__text {
+    color: #dcddde;
+}
+
+.rc-tags {
+    border-color: #4f545c;
+    border-radius: 8px;
+    color: #dcddde;
+}
+
 .hljs {
 	display: block;
 	overflow-x: auto;


### PR DESCRIPTION
The create channel/discussion window still had dark (black) headers which were unreadable.

And for some reason the **Channel name** input is styled on the `<input>` tag itself.
But the **Invite users** input was styled by the parent `<div>` tag. css class: `.rc-tags`

So both inputs had a different style, this update also makes them the same style.