### PR TITLE
Fixed directory listing (dark theme css)

### DIFF
--- a/docs/RocketChat/CSS/RocketChat-DarkTheme.css
+++ b/docs/RocketChat/CSS/RocketChat-DarkTheme.css
@@ -242,6 +242,14 @@ option {
     color: #dcddde;
 }
 
+.rc-table tbody tr:not(.table-no-click):not(.table-no-pointer):hover {
+    background-color: #1f2329;
+}
+
+.tabs {
+    border-bottom: 2px solid hsla(0,0%,85%,.4);
+}
+
 .hljs {
 	display: block;
 	overflow-x: auto;


### PR DESCRIPTION
The directory listing had light `:hover` highlights which looked bad and made the text slightly unreadable.
Also the border under the **channels** and **users** tab list looked too bright in contrast to other elements.